### PR TITLE
Improve keyword filtering system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ config/bot-config.json
 db/migration/v2-database.db
 db/migration/launchbot.db
 CLAUDE.md
+*.db

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ launchbot
 config/bot-config.json
 db/migration/v2-database.db
 db/migration/launchbot.db
+CLAUDE.md

--- a/bots/telegram/commands.go
+++ b/bots/telegram/commands.go
@@ -928,10 +928,19 @@ func (tg *Bot) keywordsCallback(ctx tb.Context) error {
 	case "mode":
 		if callbackData[1] == "toggle" {
 			// Toggle filter mode
-			modes := []string{"exclude", "include", "hybrid"}
+			// Map legacy modes to new modes
+			currentMode := chat.FilterMode
+			if currentMode == "exclude" {
+				currentMode = "keywords_filter"
+			} else if currentMode == "hybrid" {
+				currentMode = "keywords_add"
+			}
+			
+			// Define available modes
+			modes := []string{"keywords_filter", "keywords_add", "include"}
 			currentIdx := 0
 			for i, mode := range modes {
-				if chat.FilterMode == mode {
+				if currentMode == mode {
 					currentIdx = i
 					break
 				}

--- a/bots/telegram/sender.go
+++ b/bots/telegram/sender.go
@@ -396,8 +396,8 @@ func (tg *Bot) NotificationWorker(id int, jobChannel chan MessageJob) {
 			if success {
 				job.Recipient.Stats.ReceivedNotifications++
 			} else {
-				log.Warn().Msgf("[Worker=%d] Sending notification to chat=%s failed [%s]",
-					id, job.Recipient.Id, job.Id)
+				log.Warn().Msgf("[Worker=%d] Sending notification to chat=%s failed [%s] - type=%s",
+					id, job.Recipient.Id, job.Id, job.Recipient.Type)
 			}
 
 			job.Results <- idPair

--- a/bots/telegram/telegram.go
+++ b/bots/telegram/telegram.go
@@ -519,7 +519,12 @@ func (tg *Bot) LoadChatFromUser(user *users.User) *tb.Chat {
 	chat, err := tg.Bot.ChatByID(id)
 
 	if err != nil {
-		log.Error().Err(err).Msgf("Loading user=%s failed", user.Id)
+		// Check if this is a "chat not found" error
+		if strings.Contains(err.Error(), "chat not found") {
+			log.Warn().Err(err).Msgf("Chat not found when loading user=%s - chat may have been deleted", user.Id)
+		} else {
+			log.Error().Err(err).Msgf("Loading user=%s failed", user.Id)
+		}
 		return nil
 	}
 
@@ -569,5 +574,7 @@ func (tg *Bot) loadChatType(user *users.User) {
 	if tbChat != nil {
 		user.Type = TelegramChatToUserType(tbChat)
 		log.Debug().Msgf("Loaded user-type=%s for chat=%s", user.Type, user.Id)
+	} else {
+		log.Debug().Msgf("Failed to load chat type for user=%s - continuing without type", user.Id)
 	}
 }

--- a/bots/telegram/telegram.go
+++ b/bots/telegram/telegram.go
@@ -110,6 +110,7 @@ func (tg *Bot) Initialize(token string) {
 	tg.Bot.Handle(&tb.InlineButton{Unique: "countryCodeView"}, tg.settingsCountryCodeView)
 	tg.Bot.Handle(&tb.InlineButton{Unique: "notificationToggle"}, tg.notificationToggleCallback)
 	tg.Bot.Handle(&tb.InlineButton{Unique: "muteToggle"}, tg.muteCallback)
+	tg.Bot.Handle(&tb.InlineButton{Unique: "keywords"}, tg.keywordsCallback)
 	tg.Bot.Handle(&tb.InlineButton{Unique: "expand"}, tg.expandMessageContent)
 	tg.Bot.Handle(&tb.InlineButton{Unique: "admin"}, tg.adminCommand)
 
@@ -118,6 +119,9 @@ func (tg *Bot) Initialize(token string) {
 
 	// Handle incoming locations for time-zone setup messages
 	tg.Bot.Handle(tb.OnLocation, tg.locationReplyHandler)
+
+	// Handle text messages for keyword input
+	tg.Bot.Handle(tb.OnText, tg.textMessageHandler)
 
 	// Catch service messages as they happen
 	tg.Bot.Handle(tb.OnMigration, tg.migrationHandler)

--- a/bots/telegram/telegram.go
+++ b/bots/telegram/telegram.go
@@ -103,19 +103,19 @@ func (tg *Bot) Initialize(token string) {
 	tg.Bot.Handle("/send", tg.fauxNotification)
 
 	// Handle callbacks by button-type
-	tg.Bot.Handle(&tb.InlineButton{Unique: "next"}, tg.nextHandler)
-	tg.Bot.Handle(&tb.InlineButton{Unique: "schedule"}, tg.scheduleHandler)
-	tg.Bot.Handle(&tb.InlineButton{Unique: "stats"}, tg.statsHandler)
-	tg.Bot.Handle(&tb.InlineButton{Unique: "settings"}, tg.settingsCallback)
-	tg.Bot.Handle(&tb.InlineButton{Unique: "countryCodeView"}, tg.settingsCountryCodeView)
-	tg.Bot.Handle(&tb.InlineButton{Unique: "notificationToggle"}, tg.notificationToggleCallback)
-	tg.Bot.Handle(&tb.InlineButton{Unique: "muteToggle"}, tg.muteCallback)
-	tg.Bot.Handle(&tb.InlineButton{Unique: "keywords"}, tg.keywordsCallback)
-	tg.Bot.Handle(&tb.InlineButton{Unique: "expand"}, tg.expandMessageContent)
-	tg.Bot.Handle(&tb.InlineButton{Unique: "admin"}, tg.adminCommand)
+	tg.Bot.Handle(&tb.InlineButton{Unique: "next"}, tg.wrapCallbackHandler(tg.nextHandler))
+	tg.Bot.Handle(&tb.InlineButton{Unique: "schedule"}, tg.wrapCallbackHandler(tg.scheduleHandler))
+	tg.Bot.Handle(&tb.InlineButton{Unique: "stats"}, tg.wrapCallbackHandler(tg.statsHandler))
+	tg.Bot.Handle(&tb.InlineButton{Unique: "settings"}, tg.wrapCallbackHandler(tg.settingsCallback))
+	tg.Bot.Handle(&tb.InlineButton{Unique: "countryCodeView"}, tg.wrapCallbackHandler(tg.settingsCountryCodeView))
+	tg.Bot.Handle(&tb.InlineButton{Unique: "notificationToggle"}, tg.wrapCallbackHandler(tg.notificationToggleCallback))
+	tg.Bot.Handle(&tb.InlineButton{Unique: "muteToggle"}, tg.wrapCallbackHandler(tg.muteCallback))
+	tg.Bot.Handle(&tb.InlineButton{Unique: "keywords"}, tg.wrapCallbackHandler(tg.keywordsCallback))
+	tg.Bot.Handle(&tb.InlineButton{Unique: "expand"}, tg.wrapCallbackHandler(tg.expandMessageContent))
+	tg.Bot.Handle(&tb.InlineButton{Unique: "admin"}, tg.wrapCallbackHandler(tg.adminCommand))
 
 	// A generic, catch-all callback handler to help with migrations/deprecations
-	tg.Bot.Handle(tb.OnCallback, tg.genericCallbackHandler)
+	tg.Bot.Handle(tb.OnCallback, tg.wrapCallbackHandler(tg.genericCallbackHandler))
 
 	// Handle incoming locations for time-zone setup messages
 	tg.Bot.Handle(tb.OnLocation, tg.locationReplyHandler)
@@ -307,6 +307,22 @@ func (tg *Bot) genericCallbackHandler(ctx tb.Context) error {
 		chat.Id, cbData)
 
 	return tg.respondToCallback(ctx, tg.Template.Messages.Migrated(), true)
+}
+
+// wrapCallbackHandler wraps a callback handler with panic recovery
+func (tg *Bot) wrapCallbackHandler(handler func(tb.Context) error) func(tb.Context) error {
+	return func(ctx tb.Context) error {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error().Msgf("Panic in callback handler: %v", r)
+				// Try to respond to the callback to acknowledge it
+				if ctx != nil && ctx.Callback() != nil {
+					_ = tg.respondToCallback(ctx, "⚠️ An error occurred. Please try again.", false)
+				}
+			}
+		}()
+		return handler(ctx)
+	}
 }
 
 // Responds to a callback with text, show alert if configured. Always returns a nil.

--- a/bots/templates/keyboards.go
+++ b/bots/templates/keyboards.go
@@ -550,10 +550,12 @@ func (command *CommandKeyboard) Admin() (tb.SendOptions, [][]tb.InlineButton) {
 func (keywords *KeywordsKeyboard) Main(chat *users.User) (tb.SendOptions, [][]tb.InlineButton) {
 	// Get current filter mode label
 	filterModeLabel := map[string]string{
-		"exclude": "📛 Mode: Exclude keywords",
-		"include": "✅ Mode: Include only keywords",
-		"hybrid":  "🔀 Mode: Hybrid filtering",
-		"":        "📛 Mode: Exclude keywords", // Default
+		"exclude": "📛 Mode: Keywords filter",
+		"keywords_filter": "📛 Mode: Keywords filter",
+		"include": "✅ Mode: Include only",
+		"hybrid":  "🔀 Mode: Keywords add",
+		"keywords_add": "🔀 Mode: Keywords add",
+		"":        "📛 Mode: Keywords filter", // Default
 	}[chat.FilterMode]
 
 	filterModeBtn := tb.InlineButton{

--- a/bots/templates/messages.go
+++ b/bots/templates/messages.go
@@ -154,10 +154,12 @@ func (keywords *KeywordsMessage) Main(chat *users.User) string {
 
 	// Add current mode info
 	modeInfo := map[string]string{
-		"exclude": "*Current mode:* Exclude keywords - You'll receive all launches EXCEPT those matching your muted keywords.",
+		"exclude": "*Current mode:* Keywords filter - You'll receive all launches EXCEPT those matching your muted keywords.",
+		"keywords_filter": "*Current mode:* Keywords filter - You'll receive all launches EXCEPT those matching your muted keywords.",
 		"include": "*Current mode:* Include only - You'll ONLY receive launches matching your subscribed keywords.",
-		"hybrid":  "*Current mode:* Hybrid - You'll receive launches matching subscribed keywords, excluding any that also match muted keywords.",
-		"":        "*Current mode:* Exclude keywords (default)",
+		"hybrid":  "*Current mode:* Keywords add - Keywords can subscribe you to launches beyond your provider settings.",
+		"keywords_add": "*Current mode:* Keywords add - Keywords can subscribe you to launches beyond your provider settings.",
+		"":        "*Current mode:* Keywords filter (default)",
 	}[chat.FilterMode]
 
 	return base + modeInfo + "\n\n" +
@@ -196,9 +198,9 @@ func (keywords *KeywordsMessage) ViewSubscribed(chat *users.User) string {
 func (keywords *KeywordsMessage) Help() string {
 	return "❓ *LaunchBot* | *Keyword Filtering Help*\n\n" +
 		"*Filter Modes:*\n" +
-		"• *Exclude mode:* Get all launches except those matching muted keywords\n" +
-		"• *Include mode:* Only get launches matching subscribed keywords\n" +
-		"• *Hybrid mode:* Combination of both (subscribed takes precedence)\n\n" +
+		"• *Keywords filter:* Get launches from subscribed providers, excluding those matching muted keywords\n" +
+		"• *Keywords add:* Keywords can add launches even from unsubscribed providers\n" +
+		"• *Include only:* Only get launches matching subscribed keywords (legacy mode)\n\n" +
 		"*Examples:*\n" +
 		"• Mute \"Starlink\" to skip all Starlink launches\n" +
 		"• Subscribe to \"Falcon Heavy\" for only heavy-lift launches\n" +
@@ -270,9 +272,11 @@ func (keywords *KeywordsMessage) Cleared(keywordType string) string {
 // Keywords.ModeChanged
 func (keywords *KeywordsMessage) ModeChanged(newMode string) string {
 	modeDesc := map[string]string{
-		"exclude": "Exclude mode - You'll receive all launches except those matching muted keywords",
-		"include": "Include mode - You'll only receive launches matching subscribed keywords",
-		"hybrid":  "Hybrid mode - Subscribed keywords take precedence, then muted keywords are applied",
+		"exclude": "Keywords filter - You'll receive launches from subscribed providers except those matching muted keywords",
+		"keywords_filter": "Keywords filter - You'll receive launches from subscribed providers except those matching muted keywords",
+		"include": "Include only - You'll only receive launches matching subscribed keywords",
+		"hybrid":  "Keywords add - Keywords can subscribe you to launches beyond your provider settings",
+		"keywords_add": "Keywords add - Keywords can subscribe you to launches beyond your provider settings",
 	}[newMode]
 
 	return fmt.Sprintf("✅ Filter mode changed to: *%s*", modeDesc)

--- a/db/db.go
+++ b/db/db.go
@@ -114,6 +114,9 @@ func (db *Database) Open(dbFolder string) bool {
 		log.Fatal().Err(err).Msg("Running auto-migration failed")
 	}
 
+	// Run filter mode migration
+	db.migrateFilterModes()
+
 	// Set size
 	db.Path = relDbPath
 	db.SetSize()
@@ -291,4 +294,40 @@ func (db *Database) GetWeeklyActiveUserCount() int64 {
 	trailingWeek := time.Now().Add(-1 * time.Duration(24*7) * time.Hour)
 
 	return db.Conn.Where("updated_at > ?", trailingWeek).Find(&[]users.User{}).RowsAffected
+}
+
+// Migrate filter modes to new simplified system
+func (db *Database) migrateFilterModes() {
+	// Count users with hybrid mode for logging
+	var hybridCount int64
+	db.Conn.Model(&users.User{}).Where("filter_mode = ?", "hybrid").Count(&hybridCount)
+	
+	if hybridCount > 0 {
+		log.Info().Msgf("Migrating %d users from hybrid filter mode to keywords_add mode", hybridCount)
+		
+		// Update all users with hybrid mode to keywords_add
+		result := db.Conn.Model(&users.User{}).Where("filter_mode = ?", "hybrid").Update("filter_mode", "keywords_add")
+		
+		if result.Error != nil {
+			log.Error().Err(result.Error).Msg("Failed to migrate hybrid filter modes")
+		} else {
+			log.Info().Msgf("Successfully migrated %d users to keywords_add mode", result.RowsAffected)
+		}
+	}
+	
+	// Also update any "exclude" mode to "keywords_filter" for consistency
+	var excludeCount int64
+	db.Conn.Model(&users.User{}).Where("filter_mode = ?", "exclude").Count(&excludeCount)
+	
+	if excludeCount > 0 {
+		log.Info().Msgf("Migrating %d users from exclude filter mode to keywords_filter mode", excludeCount)
+		
+		result := db.Conn.Model(&users.User{}).Where("filter_mode = ?", "exclude").Update("filter_mode", "keywords_filter")
+		
+		if result.Error != nil {
+			log.Error().Err(result.Error).Msg("Failed to migrate exclude filter modes")
+		} else {
+			log.Info().Msgf("Successfully migrated %d users to keywords_filter mode", result.RowsAffected)
+		}
+	}
 }

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -58,8 +58,22 @@ func TestChatMethods(t *testing.T) {
 
 	// Open db
 	db := Database{}
-	dbFolder := "/test"
-	db.Open(dbFolder)
+	dbFolder := "test"
+	
+	// Initialize cache
+	cache := &Cache{
+		Database:  &db,
+		Launches:  []*Launch{},
+		LaunchMap: make(map[string]*Launch),
+		Users:     &users.UserCache{},
+	}
+	db.Cache = cache
+	
+	success := db.Open(dbFolder)
+	if !success {
+		t.Fatal("Failed to open database")
+	}
+	cache.Database = &db
 
 	// Add a whole bunch of users, then remove them
 	for i := 0; i < 10; i++ {

--- a/db/notification.go
+++ b/db/notification.go
@@ -158,6 +158,12 @@ func (launch *Launch) NotificationRecipients(db *Database, notificationType stri
 			continue
 		}
 
+		// Check keyword filters
+		if !user.MatchesKeywordFilter(launch.Name, launch.Rocket.Config.Name, launch.Mission.Name) {
+			log.Debug().Msgf("➙ User=%s filtered out launch=%s by keyword filter", user.Id, launch.Name)
+			continue
+		}
+
 		/* User has subscribed to this launch, and has not muted it: add to recipients.
 		However, first check if this user has already been cached, in order to avoid
 		overlapping database writes. */

--- a/db/notification_test.go
+++ b/db/notification_test.go
@@ -44,3 +44,147 @@ func TestRecipientLoading(t *testing.T) {
 	log.Debug().Msgf("Loaded %d recipients!", len(recipients))
 	log.Debug().Msgf("User-cache length: %d", len(cache.Users.InCache))
 }
+
+func TestKeywordFilteringInNotificationRecipients(t *testing.T) {
+	// Test various keyword filtering scenarios
+	tests := []struct {
+		name               string
+		launchName         string
+		vehicleName        string
+		missionName        string
+		user               users.User
+		shouldReceive      bool
+	}{
+		{
+			name:          "User with Starlink muted should not receive Starlink launch",
+			launchName:    "Starlink Group 6-23",
+			vehicleName:   "Falcon 9",
+			missionName:   "Starlink Communications",
+			user: users.User{
+				Id:            "test1",
+				Platform:      "tg",
+				Enabled24h:    true,
+				SubscribedAll: true,
+				FilterMode:    "exclude",
+				MutedKeywords: "Starlink",
+			},
+			shouldReceive: false,
+		},
+		{
+			name:          "User without Starlink muted should receive Starlink launch",
+			launchName:    "Starlink Group 6-23",
+			vehicleName:   "Falcon 9",
+			missionName:   "Starlink Communications",
+			user: users.User{
+				Id:            "test2",
+				Platform:      "tg",
+				Enabled24h:    true,
+				SubscribedAll: true,
+				FilterMode:    "exclude",
+				MutedKeywords: "OneWeb",
+			},
+			shouldReceive: true,
+		},
+		{
+			name:          "Include mode: User subscribed to Falcon should receive Falcon launch",
+			launchName:    "CRS-29",
+			vehicleName:   "Falcon 9",
+			missionName:   "ISS Resupply",
+			user: users.User{
+				Id:                 "test3",
+				Platform:           "tg",
+				Enabled24h:         true,
+				SubscribedAll:      true,
+				FilterMode:         "include",
+				SubscribedKeywords: "Falcon",
+			},
+			shouldReceive: true,
+		},
+		{
+			name:          "Include mode: User not subscribed to vehicle should not receive",
+			launchName:    "USSF-51",
+			vehicleName:   "Atlas V",
+			missionName:   "Military",
+			user: users.User{
+				Id:                 "test4",
+				Platform:           "tg",
+				Enabled24h:         true,
+				SubscribedAll:      true,
+				FilterMode:         "include",
+				SubscribedKeywords: "Falcon,Dragon",
+			},
+			shouldReceive: false,
+		},
+		{
+			name:          "Hybrid mode: Subscribed but also muted should not receive",
+			launchName:    "Starlink Group 6-23",
+			vehicleName:   "Falcon 9",
+			missionName:   "Starlink Communications",
+			user: users.User{
+				Id:                 "test5",
+				Platform:           "tg",
+				Enabled24h:         true,
+				SubscribedAll:      true,
+				FilterMode:         "hybrid",
+				SubscribedKeywords: "Falcon",
+				MutedKeywords:      "Starlink",
+			},
+			shouldReceive: false,
+		},
+		{
+			name:          "Case insensitive keyword matching",
+			launchName:    "STARLINK Mission",
+			vehicleName:   "Falcon 9",
+			missionName:   "Communications",
+			user: users.User{
+				Id:            "test6",
+				Platform:      "tg",
+				Enabled24h:    true,
+				SubscribedAll: true,
+				FilterMode:    "exclude",
+				MutedKeywords: "starlink",
+			},
+			shouldReceive: false,
+		},
+		{
+			name:          "Partial keyword matching",
+			launchName:    "Starship Test Flight",
+			vehicleName:   "Starship",
+			missionName:   "Test",
+			user: users.User{
+				Id:                 "test7",
+				Platform:           "tg",
+				Enabled24h:         true,
+				SubscribedAll:      true,
+				FilterMode:         "include",
+				SubscribedKeywords: "Star",
+			},
+			shouldReceive: true,
+		},
+		{
+			name:          "Multiple keywords with comma separation",
+			launchName:    "OneWeb Launch 17",
+			vehicleName:   "Soyuz",
+			missionName:   "Communications",
+			user: users.User{
+				Id:            "test8",
+				Platform:      "tg",
+				Enabled24h:    true,
+				SubscribedAll: true,
+				FilterMode:    "exclude",
+				MutedKeywords: "Starlink,OneWeb,Iridium",
+			},
+			shouldReceive: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test the keyword filter directly
+			result := tt.user.MatchesKeywordFilter(tt.launchName, tt.vehicleName, tt.missionName)
+			if result != tt.shouldReceive {
+				t.Errorf("MatchesKeywordFilter: expected %v, got %v", tt.shouldReceive, result)
+			}
+		})
+	}
+}

--- a/users/users.go
+++ b/users/users.go
@@ -107,7 +107,7 @@ func (user *User) ToggleLaunchMute(id string, toggleTo bool) bool {
 	if toggleTo == user.HasMutedLaunch(id) {
 		log.Warn().Msgf("New mute status equals current mute status! Id=%s, user=%s, state=%v",
 			id, user.Id, toggleTo)
-		return true
+		return false
 	}
 
 	// If launch is being muted, just append it to the field of muted launches

--- a/users/users_test.go
+++ b/users/users_test.go
@@ -300,3 +300,80 @@ func TestMatchesKeywordFilter(t *testing.T) {
 		})
 	}
 }
+
+func TestToggleLaunchMute(t *testing.T) {
+	// Create a test user
+	user := &User{
+		Id:            "123",
+		Platform:      "test",
+		MutedLaunches: "",
+	}
+
+	launchID := "test-launch-123"
+
+	// Test muting a launch
+	t.Run("Mute unmuted launch", func(t *testing.T) {
+		result := user.ToggleLaunchMute(launchID, true)
+		if !result {
+			t.Error("Expected true when muting unmuted launch")
+		}
+		if !user.HasMutedLaunch(launchID) {
+			t.Error("Launch should be muted")
+		}
+	})
+
+	// Test muting already muted launch
+	t.Run("Mute already muted launch", func(t *testing.T) {
+		result := user.ToggleLaunchMute(launchID, true)
+		if result {
+			t.Error("Expected false when muting already muted launch")
+		}
+		if !user.HasMutedLaunch(launchID) {
+			t.Error("Launch should still be muted")
+		}
+	})
+
+	// Test unmuting a muted launch
+	t.Run("Unmute muted launch", func(t *testing.T) {
+		result := user.ToggleLaunchMute(launchID, false)
+		if !result {
+			t.Error("Expected true when unmuting muted launch")
+		}
+		if user.HasMutedLaunch(launchID) {
+			t.Error("Launch should be unmuted")
+		}
+	})
+
+	// Test unmuting already unmuted launch
+	t.Run("Unmute already unmuted launch", func(t *testing.T) {
+		result := user.ToggleLaunchMute(launchID, false)
+		if result {
+			t.Error("Expected false when unmuting already unmuted launch")
+		}
+		if user.HasMutedLaunch(launchID) {
+			t.Error("Launch should still be unmuted")
+		}
+	})
+
+	// Test with multiple launches
+	t.Run("Multiple launches", func(t *testing.T) {
+		launch1 := "launch-1"
+		launch2 := "launch-2"
+		launch3 := "launch-3"
+
+		// Mute multiple launches
+		user.ToggleLaunchMute(launch1, true)
+		user.ToggleLaunchMute(launch2, true)
+		user.ToggleLaunchMute(launch3, true)
+
+		if !user.HasMutedLaunch(launch1) || !user.HasMutedLaunch(launch2) || !user.HasMutedLaunch(launch3) {
+			t.Error("All launches should be muted")
+		}
+
+		// Unmute middle launch
+		user.ToggleLaunchMute(launch2, false)
+		if !user.HasMutedLaunch(launch1) || user.HasMutedLaunch(launch2) || !user.HasMutedLaunch(launch3) {
+			t.Error("Only launch2 should be unmuted")
+		}
+	})
+}

--- a/users/users_test.go
+++ b/users/users_test.go
@@ -1,0 +1,302 @@
+package users
+
+import (
+	"testing"
+)
+
+func TestAddMutedKeyword(t *testing.T) {
+	user := &User{}
+	
+	// Test adding first keyword
+	if !user.AddMutedKeyword("Starlink") {
+		t.Error("Failed to add first muted keyword")
+	}
+	if user.MutedKeywords != "Starlink" {
+		t.Errorf("Expected MutedKeywords to be 'Starlink', got '%s'", user.MutedKeywords)
+	}
+	
+	// Test adding second keyword
+	if !user.AddMutedKeyword("OneWeb") {
+		t.Error("Failed to add second muted keyword")
+	}
+	if user.MutedKeywords != "Starlink,OneWeb" {
+		t.Errorf("Expected MutedKeywords to be 'Starlink,OneWeb', got '%s'", user.MutedKeywords)
+	}
+	
+	// Test adding duplicate keyword
+	if user.AddMutedKeyword("Starlink") {
+		t.Error("Should not add duplicate keyword")
+	}
+	
+	// Test case-insensitive duplicate check
+	if user.AddMutedKeyword("starlink") {
+		t.Error("Should not add case-insensitive duplicate keyword")
+	}
+}
+
+func TestRemoveMutedKeyword(t *testing.T) {
+	user := &User{MutedKeywords: "Starlink,OneWeb,Falcon"}
+	
+	// Test removing middle keyword
+	if !user.RemoveMutedKeyword("OneWeb") {
+		t.Error("Failed to remove keyword")
+	}
+	if user.MutedKeywords != "Starlink,Falcon" {
+		t.Errorf("Expected MutedKeywords to be 'Starlink,Falcon', got '%s'", user.MutedKeywords)
+	}
+	
+	// Test removing first keyword
+	if !user.RemoveMutedKeyword("Starlink") {
+		t.Error("Failed to remove first keyword")
+	}
+	if user.MutedKeywords != "Falcon" {
+		t.Errorf("Expected MutedKeywords to be 'Falcon', got '%s'", user.MutedKeywords)
+	}
+	
+	// Test removing last keyword
+	if !user.RemoveMutedKeyword("Falcon") {
+		t.Error("Failed to remove last keyword")
+	}
+	if user.MutedKeywords != "" {
+		t.Errorf("Expected MutedKeywords to be empty, got '%s'", user.MutedKeywords)
+	}
+	
+	// Test removing non-existent keyword
+	if user.RemoveMutedKeyword("NotThere") {
+		t.Error("Should not remove non-existent keyword")
+	}
+	
+	// Test case-insensitive removal
+	user.MutedKeywords = "Starlink"
+	if !user.RemoveMutedKeyword("STARLINK") {
+		t.Error("Failed to remove keyword with different case")
+	}
+}
+
+func TestHasMutedKeyword(t *testing.T) {
+	user := &User{MutedKeywords: "Starlink,OneWeb,Falcon"}
+	
+	// Test existing keywords
+	if !user.HasMutedKeyword("Starlink") {
+		t.Error("Should find Starlink")
+	}
+	if !user.HasMutedKeyword("OneWeb") {
+		t.Error("Should find OneWeb")
+	}
+	if !user.HasMutedKeyword("Falcon") {
+		t.Error("Should find Falcon")
+	}
+	
+	// Test case-insensitive check
+	if !user.HasMutedKeyword("starlink") {
+		t.Error("Should find starlink (case-insensitive)")
+	}
+	if !user.HasMutedKeyword("ONEWEB") {
+		t.Error("Should find ONEWEB (case-insensitive)")
+	}
+	
+	// Test non-existent keyword
+	if user.HasMutedKeyword("Dragon") {
+		t.Error("Should not find Dragon")
+	}
+	
+	// Test empty keywords
+	user.MutedKeywords = ""
+	if user.HasMutedKeyword("Anything") {
+		t.Error("Should not find anything when keywords are empty")
+	}
+}
+
+func TestSubscribedKeywordFunctions(t *testing.T) {
+	user := &User{}
+	
+	// Test add
+	if !user.AddSubscribedKeyword("ISS") {
+		t.Error("Failed to add subscribed keyword")
+	}
+	if user.SubscribedKeywords != "ISS" {
+		t.Errorf("Expected SubscribedKeywords to be 'ISS', got '%s'", user.SubscribedKeywords)
+	}
+	
+	// Test has
+	if !user.HasSubscribedKeyword("ISS") {
+		t.Error("Should find ISS")
+	}
+	if !user.HasSubscribedKeyword("iss") {
+		t.Error("Should find iss (case-insensitive)")
+	}
+	
+	// Test remove
+	if !user.RemoveSubscribedKeyword("ISS") {
+		t.Error("Failed to remove subscribed keyword")
+	}
+	if user.SubscribedKeywords != "" {
+		t.Errorf("Expected SubscribedKeywords to be empty, got '%s'", user.SubscribedKeywords)
+	}
+}
+
+func TestMatchesKeywordFilter(t *testing.T) {
+	tests := []struct {
+		name               string
+		user               User
+		launchName         string
+		vehicleName        string
+		missionName        string
+		expectedMatch      bool
+	}{
+		// Exclude mode tests
+		{
+			name:          "Exclude mode - no keywords",
+			user:          User{FilterMode: "exclude"},
+			launchName:    "Starlink Mission",
+			vehicleName:   "Falcon 9",
+			missionName:   "Communications",
+			expectedMatch: true,
+		},
+		{
+			name:          "Exclude mode - match muted keyword",
+			user:          User{FilterMode: "exclude", MutedKeywords: "Starlink"},
+			launchName:    "Starlink Mission",
+			vehicleName:   "Falcon 9",
+			missionName:   "Communications",
+			expectedMatch: false,
+		},
+		{
+			name:          "Exclude mode - no match",
+			user:          User{FilterMode: "exclude", MutedKeywords: "OneWeb"},
+			launchName:    "Starlink Mission",
+			vehicleName:   "Falcon 9",
+			missionName:   "Communications",
+			expectedMatch: true,
+		},
+		{
+			name:          "Exclude mode - partial match",
+			user:          User{FilterMode: "exclude", MutedKeywords: "Star"},
+			launchName:    "Starlink Mission",
+			vehicleName:   "Falcon 9",
+			missionName:   "Communications",
+			expectedMatch: false,
+		},
+		{
+			name:          "Exclude mode - case insensitive",
+			user:          User{FilterMode: "exclude", MutedKeywords: "starlink"},
+			launchName:    "STARLINK Mission",
+			vehicleName:   "Falcon 9",
+			missionName:   "Communications",
+			expectedMatch: false,
+		},
+		
+		// Include mode tests
+		{
+			name:          "Include mode - no keywords",
+			user:          User{FilterMode: "include"},
+			launchName:    "Starlink Mission",
+			vehicleName:   "Falcon 9",
+			missionName:   "Communications",
+			expectedMatch: true,
+		},
+		{
+			name:          "Include mode - match subscribed keyword",
+			user:          User{FilterMode: "include", SubscribedKeywords: "Starlink"},
+			launchName:    "Starlink Mission",
+			vehicleName:   "Falcon 9",
+			missionName:   "Communications",
+			expectedMatch: true,
+		},
+		{
+			name:          "Include mode - no match",
+			user:          User{FilterMode: "include", SubscribedKeywords: "ISS"},
+			launchName:    "Starlink Group 6-23",
+			vehicleName:   "Falcon 9",
+			missionName:   "Communications",
+			expectedMatch: false,
+		},
+		{
+			name:          "Include mode - match in vehicle",
+			user:          User{FilterMode: "include", SubscribedKeywords: "Falcon"},
+			launchName:    "Starlink Mission",
+			vehicleName:   "Falcon 9",
+			missionName:   "Communications",
+			expectedMatch: true,
+		},
+		{
+			name:          "Include mode - match in mission",
+			user:          User{FilterMode: "include", SubscribedKeywords: "Communications"},
+			launchName:    "Starlink Mission",
+			vehicleName:   "Falcon 9",
+			missionName:   "Communications Satellite",
+			expectedMatch: true,
+		},
+		
+		// Hybrid mode tests
+		{
+			name:          "Hybrid mode - match subscribed, not muted",
+			user:          User{FilterMode: "hybrid", SubscribedKeywords: "Falcon", MutedKeywords: "OneWeb"},
+			launchName:    "Starlink Mission",
+			vehicleName:   "Falcon 9",
+			missionName:   "Communications",
+			expectedMatch: true,
+		},
+		{
+			name:          "Hybrid mode - match subscribed and muted",
+			user:          User{FilterMode: "hybrid", SubscribedKeywords: "Falcon", MutedKeywords: "Starlink"},
+			launchName:    "Starlink Mission",
+			vehicleName:   "Falcon 9",
+			missionName:   "Communications",
+			expectedMatch: false,
+		},
+		{
+			name:          "Hybrid mode - no subscribed match",
+			user:          User{FilterMode: "hybrid", SubscribedKeywords: "ISS", MutedKeywords: "Starlink"},
+			launchName:    "Starlink Mission",
+			vehicleName:   "Falcon 9",
+			missionName:   "Communications",
+			expectedMatch: false,
+		},
+		{
+			name:          "Hybrid mode - no keywords",
+			user:          User{FilterMode: "hybrid"},
+			launchName:    "Starlink Mission",
+			vehicleName:   "Falcon 9",
+			missionName:   "Communications",
+			expectedMatch: true,
+		},
+		
+		// Default/empty filter mode
+		{
+			name:          "Default mode - should behave as exclude",
+			user:          User{MutedKeywords: "Starlink"},
+			launchName:    "Starlink Mission",
+			vehicleName:   "Falcon 9",
+			missionName:   "Communications",
+			expectedMatch: false,
+		},
+		
+		// Multiple keywords
+		{
+			name:          "Multiple muted keywords",
+			user:          User{FilterMode: "exclude", MutedKeywords: "OneWeb,Starlink,Iridium"},
+			launchName:    "Starlink Mission",
+			vehicleName:   "Falcon 9",
+			missionName:   "Communications",
+			expectedMatch: false,
+		},
+		{
+			name:          "Multiple subscribed keywords",
+			user:          User{FilterMode: "include", SubscribedKeywords: "ISS,Dragon,Crew"},
+			launchName:    "Crew-5 Mission",
+			vehicleName:   "Falcon 9",
+			missionName:   "ISS Crew Rotation",
+			expectedMatch: true,
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.user.MatchesKeywordFilter(tt.launchName, tt.vehicleName, tt.missionName)
+			if result != tt.expectedMatch {
+				t.Errorf("Expected %v, got %v", tt.expectedMatch, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Makes keyword filtering more intuitive by allowing keywords to subscribe to launches beyond provider settings.

## Changes
- Add `keywords_add` mode where keywords can add launches from any provider
- Rename `exclude` to `keywords_filter` for clarity
- Add unified `ShouldReceiveLaunch` method for cleaner logic
- Auto-migrate existing user settings
- Update UI text to reflect new behavior

## Testing
- Added comprehensive unit tests
- Existing functionality preserved through migration