### PR TITLE
Update Go version and dependencies

### DIFF
--- a/api/scheduler.go
+++ b/api/scheduler.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"fmt"
 	"launchbot/config"
 	"launchbot/db"
@@ -9,7 +8,6 @@ import (
 	"time"
 
 	"github.com/hako/durafmt"
-	"github.com/procyon-projects/chrono"
 	"github.com/rs/zerolog/log"
 	tb "gopkg.in/telebot.v3"
 )
@@ -112,7 +110,7 @@ func Notify(launch *db.Launch, database *db.Database, username string) *sendable
 }
 
 // NotificationWrapper is called when scheduled notifications are prepared for sending.
-func notificationWrapper(session *config.Session, launchIds []string, refreshData bool) bool {
+func notificationWrapper(session *config.Session, launchIds []string, refreshData bool) {
 	if refreshData {
 		// Run updater
 		updateWrapper(session, false)
@@ -121,7 +119,8 @@ func notificationWrapper(session *config.Session, launchIds []string, refreshDat
 		_, notification := session.Cache.NextScheduledUpdateIn()
 
 		// Re-schedule notifications
-		return NotificationScheduler(session, notification, false)
+		NotificationScheduler(session, notification, false)
+		return
 	} else {
 		log.Debug().Msg("Not refreshing data before notification scheduling...")
 	}
@@ -157,8 +156,6 @@ func notificationWrapper(session *config.Session, launchIds []string, refreshDat
 
 	// Notifications processed: queue post-launch check if this is a 5-minute notification
 	Scheduler(session, false, postLaunchUpdate, false)
-
-	return true
 }
 
 // Schedules a chrono job for when the notification should be sent, with some
@@ -179,21 +176,17 @@ func NotificationScheduler(session *config.Session, notifTime *db.Notification, 
 	}
 
 	// Create task
-	task, err := session.Scheduler.Schedule(func(ctx context.Context) {
-		// Run notification sender
-		success := notificationWrapper(session, notifTime.IDs, refresh)
-		log.Debug().Msgf("NotificationScheduler task: notificationWrapper returned %v", success)
-	}, chrono.WithTime(scheduledTime))
+	job, err := session.Scheduler.At(scheduledTime).Do(notificationWrapper, session, notifTime.IDs, refresh)
 
 	if err != nil {
 		log.Error().Err(err).Msg("Error creating notification task!")
 		return false
 	}
 
-	// Lock session, add task to list of scheduled tasks
+	// Lock session, add job to list of scheduled jobs
 	session.Mutex.Lock()
 
-	session.NotificationTasks[scheduledTime] = &task
+	session.NotificationTasks[scheduledTime] = job
 
 	session.Mutex.Unlock()
 
@@ -266,18 +259,16 @@ func Scheduler(session *config.Session, startup bool, postLaunchCheck *PostLaunc
 	}
 
 	// Schedule next auto-update, since no notifications are incoming soon
-	task, err := session.Scheduler.Schedule(func(ctx context.Context) {
-		updateWrapper(session, true)
-	}, chrono.WithTime(autoUpdateTime))
+	job, err := session.Scheduler.At(autoUpdateTime).Do(updateWrapper, session, true)
 
 	if err != nil {
 		log.Error().Err(err).Msgf("Scheduling next update failed")
 		return false
 	}
 
-	// Lock session, add task to list of scheduled tasks
+	// Lock session, add job to list of scheduled jobs
 	session.Mutex.Lock()
-	session.Tasks = append(session.Tasks, &task)
+	session.Tasks = append(session.Tasks, job)
 	session.Mutex.Unlock()
 
 	log.Info().Msgf("Next auto-update in %s (%s)",
@@ -303,9 +294,8 @@ func Scheduler(session *config.Session, startup bool, postLaunchCheck *PostLaunc
 			if untilNotification > time.Duration(2)*time.Hour && postLaunchCheck == nil {
 				/* More than two hours until next notif, more than an hour until next API
 				update, no post-launch check scheduled. Schedule a cache flush for later */
-				_, err := session.Scheduler.Schedule(func(ctx context.Context) {
-					session.Cache.CleanUserCache(session.Db, false, false)
-				}, chrono.WithTime(time.Now().Add(time.Minute*time.Duration(15))))
+				_, err := session.Scheduler.At(time.Now().Add(time.Minute*time.Duration(15))).Do(
+					session.Cache.CleanUserCache, session.Db, false, false)
 
 				if err != nil {
 					log.Error().Err(err).Msg("Scheduling user-cache flush for later failed")

--- a/bots/telegram/commands.go
+++ b/bots/telegram/commands.go
@@ -221,7 +221,7 @@ func (tg *Bot) feedbackHandler(ctx tb.Context) error {
 
 	// Command has parameters: log feedback, send to owner
 	feedbackLog := fmt.Sprintf("✍️ *Got feedback from %s:* %s", chat.Id, ctx.Data())
-	log.Info().Msgf(feedbackLog)
+	log.Info().Msg(feedbackLog)
 
 	tg.Enqueue(
 		sendables.TextOnlySendable(

--- a/cmd/launchbot.go
+++ b/cmd/launchbot.go
@@ -15,7 +15,6 @@ import (
 	"github.com/go-co-op/gocron"
 	"github.com/rs/zerolog/pkgerrors"
 
-	"github.com/procyon-projects/chrono"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
@@ -130,7 +129,7 @@ func main() {
 
 	if !noUpdates {
 		// Create a new task scheduler, assign to session
-		session.Scheduler = chrono.NewDefaultTaskScheduler()
+		session.Scheduler = gocron.NewScheduler(time.UTC)
 
 		// Populate the cache
 		session.Cache.Populate()

--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/procyon-projects/chrono"
+	"github.com/go-co-op/gocron"
 	"github.com/rs/zerolog/log"
 )
 
@@ -28,9 +28,9 @@ type Session struct {
 	Config            *Config                             // Configuration for session
 	Cache             *db.Cache                           // Launch cache
 	Db                *db.Database                        // Pointer to the database object
-	Scheduler         chrono.TaskScheduler                // Chrono scheduler
-	Tasks             []*chrono.ScheduledTask             // List of Chrono tasks
-	NotificationTasks map[time.Time]*chrono.ScheduledTask // Map a time to a scheduled Chrono task
+	Scheduler         *gocron.Scheduler                   // Gocron scheduler
+	Tasks             []*gocron.Job                       // List of Gocron jobs
+	NotificationTasks map[time.Time]*gocron.Job           // Map a time to a scheduled Gocron job
 	Scheduled         []string                            // A list of launch IDs that have a notification scheduled
 	Version           string                              // Version number
 	Started           time.Time                           // Unix timestamp of startup time
@@ -60,7 +60,7 @@ func (session *Session) Initialize() {
 	session.Config = LoadConfig()
 
 	// Init notification task map
-	session.NotificationTasks = make(map[time.Time]*chrono.ScheduledTask)
+	session.NotificationTasks = make(map[time.Time]*gocron.Job)
 
 	// Initialize cache
 	session.Cache = &db.Cache{

--- a/go.mod
+++ b/go.mod
@@ -1,25 +1,27 @@
 module launchbot
 
-go 1.19
+go 1.24
 
 require (
-	github.com/rs/zerolog v1.29.1
-	gopkg.in/telebot.v3 v3.1.3
+	github.com/rs/zerolog v1.34.0
+	gopkg.in/telebot.v3 v3.3.8
 )
 
 require (
 	github.com/deckarep/golang-set v1.8.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jonas-p/go-shp v0.1.1 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.18 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mingrammer/commonregex v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
-	golang.org/x/image v0.2.0 // indirect
-	golang.org/x/net v0.9.0 // indirect
-	golang.org/x/sync v0.1.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
+	golang.org/x/image v0.29.0 // indirect
+	golang.org/x/net v0.42.0 // indirect
+	golang.org/x/text v0.27.0 // indirect
 	gonum.org/v1/gonum v0.12.0 // indirect
 	gopkg.in/neurosnap/sentences.v1 v1.0.7 // indirect
 )
@@ -27,16 +29,15 @@ require (
 require (
 	github.com/bradfitz/latlong v0.0.0-20170410180902-f3db6d0dff40
 	github.com/dustin/go-humanize v1.0.1
-	github.com/go-co-op/gocron v1.22.1
-	github.com/go-resty/resty/v2 v2.7.0
+	github.com/go-co-op/gocron v1.37.0
+	github.com/go-resty/resty/v2 v2.16.5
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	github.com/jayco/go-emoji-flag v0.0.0-20190810054606-01604da018da
 	github.com/jdkato/prose/v2 v2.0.0
-	github.com/mattn/go-sqlite3 v1.14.16 // indirect
-	github.com/procyon-projects/chrono v1.1.2
-	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
-	golang.org/x/sys v0.7.0
-	golang.org/x/time v0.3.0
-	gorm.io/driver/sqlite v1.5.0
-	gorm.io/gorm v1.25.0
+	github.com/mattn/go-sqlite3 v1.14.30 // indirect
+	golang.org/x/exp v0.0.0-20250718183923-645b1fa84792
+	golang.org/x/sys v0.34.0
+	golang.org/x/time v0.6.0
+	gorm.io/driver/sqlite v1.6.0
+	gorm.io/gorm v1.30.1
 )

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ The above only applies on a per-bot-instance basis. The creator of the bot choos
 
 - `dustin/go-humanize`: used to produce various human-friendly strings, such as time- and unit-related ones.
 
-- `go-co-op/gocron`: used to schedule regular function calls, for e.g. dumping statistics to the disk.
+- `go-co-op/gocron`: used to schedule API calls, notifications at specific times, and regular function calls like dumping statistics to disk.
 
 - `go-resty/resty/v2`: a great alternative to the standard http library, with exponential back-off baked in.
 
@@ -76,7 +76,6 @@ The above only applies on a per-bot-instance basis. The creator of the bot choos
 
 - `jdkato/prose/v2`: natural language parsing for LL2's launch descriptions.
 
-- `procyon-projects/chrono`: used to schedule API calls and notifications to a specific point in time.
 
 - `gorm`: a fantastic ORM library for Go, used with the main SQLite database.
 


### PR DESCRIPTION
## Summary
- Updated Go from 1.19 to 1.24
- Updated all dependencies to their latest stable versions
- Replaced chrono scheduler with gocron to resolve module path issues

## Changes
### Go Version
- Updated from Go 1.19 to Go 1.24

### Dependency Updates
- `rs/zerolog` v1.29.1 → v1.34.0
- `telebot` v3.1.3 → v3.3.8  
- `go-co-op/gocron` v1.22.1 → v1.37.0
- `go-resty/resty` v2.7.0 → v2.16.5
- `gorm` v1.25.0 → v1.30.1
- `gorm/driver/sqlite` v1.5.0 → v1.6.0
- Various `golang.org/x` packages updated to latest versions

### Chrono → Gocron Migration
- Removed dependency on `procyon-projects/chrono` due to module path issues (declares path as `codnect.io/chrono`)
- Migrated all time-based scheduling to use `gocron`'s `At()` method
- Simplified scheduling architecture using a single scheduler for both interval and time-based tasks
- Updated documentation to reflect the change

### Additional Fixes
- Fixed non-constant format string warning in `commands.go`

## Test Results
- All tests pass except for a pre-existing db test failure (unrelated to these changes)
- Project builds successfully
- Binary size: ~21MB

## Notes
The chrono library had changed its module path which made it incompatible. Since gocron was already in use for interval scheduling and supports time-based scheduling via the `At()` method, consolidating to a single scheduler library simplified the codebase.