### PR TITLE
Fix logging to handle absolute paths

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -8,13 +8,18 @@ import (
 )
 
 func SetupLogFile(logFolder string) *os.File {
-	// Logpath relative to current working directory
-	wd, _ := os.Getwd()
-	logPath := filepath.Join(wd, logFolder)
+	// Determine absolute path for log folder
+	var logPath string
+	if filepath.IsAbs(logFolder) {
+		logPath = logFolder
+	} else {
+		wd, _ := os.Getwd()
+		logPath = filepath.Join(wd, logFolder)
+	}
 
 	// If folders do not exist, create them
 	if _, err := os.Stat(logPath); os.IsNotExist(err) {
-		_ = os.Mkdir(logPath, os.ModePerm)
+		_ = os.MkdirAll(logPath, os.ModePerm)
 	}
 
 	logFilePath := filepath.Join(logPath, "launchbot-logs.log")


### PR DESCRIPTION
Fixes an issue where log files weren't created in the correct location when using absolute paths via environment variables or command-line flags.

The logging setup was always prepending the working directory, even for absolute paths. This caused logs to be created in incorrect locations like `/cwd/home/user/.launchbot/` instead of `/home/user/.launchbot/`.

This fix makes the logging behavior consistent with the database path handling.