### PR TITLE
Optimize SQL queries and switch to monthly active users

### DIFF
--- a/bots/telegram/commands.go
+++ b/bots/telegram/commands.go
@@ -406,7 +406,7 @@ func (tg *Bot) statsHandler(ctx tb.Context) error {
 	// Reload some statistics
 	tg.Stats.DbSize = tg.Db.Size
 	tg.Stats.Subscribers = tg.Db.Subscribers
-	tg.Stats.WeeklyActiveUsers = tg.Db.WeeklyActiveUsers
+	tg.Stats.MonthlyActiveUsers = tg.Db.MonthlyActiveUsers
 
 	// Get text content
 	textContent := tg.Stats.String()

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -30,7 +30,7 @@ type Statistics struct {
 	NextNotification  time.Time
 	StartedAt         time.Time
 	Subscribers       int64  `gorm:"-:all"`
-	WeeklyActiveUsers int64  `gorm:"-:all"`
+	MonthlyActiveUsers int64  `gorm:"-:all"`
 	DbSize            int64  `gorm:"-:all"`
 	RunningVersion    string `gorm:"-:all"`
 }
@@ -72,7 +72,7 @@ func (stats *Statistics) String() string {
 			"Notifications delivered: %s\n"+
 			"Commands parsed: %s\n"+
 			"Active subscribers: %s\n"+
-			"Weekly active users: %s\n\n"+
+			"Monthly active users: %s\n\n"+
 
 			"🛰️ *Database information*\n"+
 			"Updated %s ago\n"+
@@ -87,7 +87,7 @@ func (stats *Statistics) String() string {
 		// General statistics
 		humanize.Comma(int64(stats.Notifications)),
 		humanize.Comma(int64(stats.Commands+stats.Callbacks+stats.V2Commands)),
-		humanize.Comma(stats.Subscribers), humanize.Comma(stats.WeeklyActiveUsers),
+		humanize.Comma(stats.Subscribers), humanize.Comma(stats.MonthlyActiveUsers),
 
 		// API update information
 		dbLastUpdated, nextNotification, humanize.Bytes(uint64(stats.DbSize)),


### PR DESCRIPTION
## Summary
- Optimize statistics SQL queries to use COUNT() instead of loading all records
- Switch from weekly to monthly active users metric for better insights
- Fix potential performance issue that was loading 1000+ user records just to count them

## Changes
- Replace `Find()` with `Count()` in `GetSubscriberCount()` and `GetWeeklyActiveUserCount()`
- Rename `GetWeeklyActiveUserCount()` to `GetMonthlyActiveUserCount()` with 30-day window
- Update all references from `WeeklyActiveUsers` to `MonthlyActiveUsers`
- Update statistics display text from "Weekly active users" to "Monthly active users"

## Performance Impact
The original query was loading all matching user records (1093 rows) into memory just to count them. Using `Count()` reduces this to a simple SQL COUNT operation, which should be nearly instantaneous.