### PR TITLE
Fix keywords block settings reply issue

### DIFF
--- a/bots/telegram/commands.go
+++ b/bots/telegram/commands.go
@@ -1498,7 +1498,7 @@ func (tg *Bot) textMessageHandler(ctx tb.Context) error {
 
 	// Check if it's a keyword input prompt
 	replyText := ctx.Message().ReplyTo.Text
-	if !strings.Contains(replyText, "Please send the keyword") {
+	if !strings.Contains(replyText, "Send me the keyword") {
 		return nil
 	}
 


### PR DESCRIPTION
The message template was changed from "Please send the keyword" to "Send me the keyword(s)" in commit 4d401f3, but the reply handler check wasn't updated to match. This caused keyword reply handling to silently fail.