### PR TITLE
feat(telegram): add forum topic support for notifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: build run debug test clean
+
+build:
+	cd cmd && ./build.sh
+
+run: build
+	./launchbot
+
+debug: build
+	./launchbot --debug
+
+test:
+	go test ./...
+
+test-v:
+	go test -v ./...
+
+clean:
+	rm -f launchbot

--- a/bots/telegram/telegram.go
+++ b/bots/telegram/telegram.go
@@ -123,6 +123,7 @@ func (tg *Bot) Initialize(token string) {
 	tg.Bot.Handle(&tb.InlineButton{Unique: "keywords"}, tg.wrapCallbackHandler(tg.keywordsCallback))
 	tg.Bot.Handle(&tb.InlineButton{Unique: "expand"}, tg.wrapCallbackHandler(tg.expandMessageContent))
 	tg.Bot.Handle(&tb.InlineButton{Unique: "admin"}, tg.wrapCallbackHandler(tg.adminCommand))
+	tg.Bot.Handle(&tb.InlineButton{Unique: "testNotifConfirm"}, tg.wrapCallbackHandler(tg.testNotifConfirmCallback))
 
 	// A generic, catch-all callback handler to help with migrations/deprecations
 	tg.Bot.Handle(tb.OnCallback, tg.wrapCallbackHandler(tg.genericCallbackHandler))

--- a/bots/templates/keyboards.go
+++ b/bots/templates/keyboards.go
@@ -27,6 +27,7 @@ type SettingsKeyboard struct {
 	TimeZone     TimeZoneKeyboard
 	Subscription SubscriptionKeyboard
 	Keywords     KeywordsKeyboard
+	Topic        TopicKeyboard
 }
 
 // Extend Settings{} with time-zone settings
@@ -39,6 +40,10 @@ type SubscriptionKeyboard struct {
 
 // Extend Settings{} with keyword filter settings
 type KeywordsKeyboard struct {
+}
+
+// Extend Settings{} with topic settings
+type TopicKeyboard struct {
 }
 
 // Command templates
@@ -109,13 +114,23 @@ func (settings *SettingsKeyboard) Group(chat *users.User) (tb.SendOptions, [][]t
 		Data:   fmt.Sprintf("cmd/all/%s", utils.ToggleBoolStateAsString[chat.AnyoneCanSendCommands]),
 	}
 
+	topicLabel := "📍 Set notification topic"
+	if chat.TopicId != 0 {
+		topicLabel = fmt.Sprintf("📍 Topic: %d (change)", chat.TopicId)
+	}
+	topicBtn := tb.InlineButton{
+		Unique: "settings",
+		Text:   topicLabel,
+		Data:   "topic/main",
+	}
+
 	retBtn := tb.InlineButton{
 		Unique: "settings",
 		Text:   "⬅️ Back to settings",
 		Data:   "main",
 	}
 
-	kb := [][]tb.InlineButton{{toggleAllCmdAccessBtn}, {retBtn}}
+	kb := [][]tb.InlineButton{{toggleAllCmdAccessBtn}, {topicBtn}, {retBtn}}
 
 	sendOptions := tb.SendOptions{
 		ParseMode:             "MarkdownV2",
@@ -662,6 +677,42 @@ func (keywords *KeywordsKeyboard) ViewAllowed(chat *users.User) (tb.SendOptions,
 		kb = append(kb, []tb.InlineButton{clearBtn})
 	}
 
+	kb = append(kb, []tb.InlineButton{retBtn})
+
+	sendOptions := tb.SendOptions{
+		ParseMode:             "MarkdownV2",
+		DisableWebPagePreview: true,
+		ReplyMarkup:           &tb.ReplyMarkup{InlineKeyboard: kb},
+		Protected:             true,
+	}
+
+	return sendOptions, kb
+}
+
+func (topic *TopicKeyboard) Main(chat *users.User) (tb.SendOptions, [][]tb.InlineButton) {
+	setBtn := tb.InlineButton{
+		Unique: "settings",
+		Text:   "📝 Set topic ID",
+		Data:   "topic/setprompt",
+	}
+
+	var kb [][]tb.InlineButton
+	if chat.TopicId != 0 {
+		clearBtn := tb.InlineButton{
+			Unique: "settings",
+			Text:   "❌ Clear (use general)",
+			Data:   "topic/clear",
+		}
+		kb = [][]tb.InlineButton{{setBtn}, {clearBtn}}
+	} else {
+		kb = [][]tb.InlineButton{{setBtn}}
+	}
+
+	retBtn := tb.InlineButton{
+		Unique: "settings",
+		Text:   "⬅️ Back to group settings",
+		Data:   "group/main",
+	}
 	kb = append(kb, []tb.InlineButton{retBtn})
 
 	sendOptions := tb.SendOptions{

--- a/bots/templates/messages.go
+++ b/bots/templates/messages.go
@@ -19,11 +19,13 @@ type SettingsMessage struct {
 	TimeZone     TimeZoneMessage
 	Subscription SubscriptionMessage
 	Keywords     KeywordsMessage
+	Topic        TopicMessage
 }
 
 type TimeZoneMessage struct{}
 type SubscriptionMessage struct{}
 type KeywordsMessage struct{}
+type TopicMessage struct{}
 type CommandMessage struct{}
 type ServiceMessage struct{}
 
@@ -284,4 +286,29 @@ func (keywords *KeywordsMessage) NotFound(keyword, keywordType string) string {
 // Keywords.Cleared
 func (keywords *KeywordsMessage) Cleared(keywordType string) string {
 	return fmt.Sprintf("✅ All %s keywords have been cleared.", keywordType)
+}
+
+// Topic.Main
+func (topic *TopicMessage) Main(topicId int64) string {
+	status := "Not configured (using general topic)"
+	if topicId != 0 {
+		status = fmt.Sprintf("Topic ID: %d", topicId)
+	}
+
+	return fmt.Sprintf("📍 *LaunchBot* | *Topic Settings*\n\n"+
+		"*Current:* %s\n\n"+
+		"*How to find your topic ID:*\n"+
+		"1. Open your forum group in Telegram\n"+
+		"2. Open the topic you want notifications in\n"+
+		"3. The topic ID is in the URL or message link\n\n"+
+		"_Set to 0 or clear to use the general topic._", status)
+}
+
+// Topic.SetPrompt
+func (topic *TopicMessage) SetPrompt() string {
+	return "📍 *Set Notification Topic*\n\n" +
+		"Reply with either:\n" +
+		"• A topic link (right-click topic → Copy Link)\n" +
+		"• The topic ID number\n\n" +
+		"_Send 0 to use the general topic._"
 }

--- a/users/users.go
+++ b/users/users.go
@@ -24,6 +24,7 @@ type User struct {
 	Enabled5min           bool     `gorm:"index:enabled;index:disabled;default:1"`
 	EnabledPostpone       bool     `gorm:"index:enabled;index:disabled;default:1"`
 	AnyoneCanSendCommands bool     // Group setting to enable non-admins to call commands
+	TopicId               int64   // Optional: forum topic ID for notifications (0 = disabled)
 	SubscribedAll         bool     `gorm:"index:enabled;index:disabled"`
 	SubscribedTo          string   // List of comma-separated LSP IDs
 	UnsubscribedFrom      string   // List of comma-separated LSP IDs


### PR DESCRIPTION
- Add TopicId field to User struct for per-chat topic configuration
- Route notifications to configured topic via ThreadID
- Preserve command response ThreadID (replies stay in same topic)
- Parse topic ID from t.me links or plain numbers
- Graceful fallback when topics are deleted/closed
- Add topic settings UI in group settings menu
- Add /send command confirmation before sending test notifications
- Add Makefile for common build/test commands